### PR TITLE
Fix "multiple definition of `hUsbClassMIDI'" error with gcc 10

### DIFF
--- a/Src/usb_device.c
+++ b/Src/usb_device.c
@@ -7,7 +7,6 @@
 #include "stm32f1xx_hal_pcd_ex.h"
 
 USBD_HandleTypeDef 		hUsbDeviceFS;
-USBD_ClassTypeDef  		hUsbClassMIDI;
 USBD_MIDI_ItfTypeDef 	hUsbClassMIDI_CB;
 
 void MX_USB_DEVICE_Init(void)


### PR DESCRIPTION
Tested ok on FreeBSD13/arm-none-eabi-gcc 10.3.1 and Debian11/arm-none-eabi-gcc 8.3.1